### PR TITLE
parameterised queries

### DIFF
--- a/test/mariadb_test.go
+++ b/test/mariadb_test.go
@@ -294,6 +294,30 @@ func Test_MariaDB_QueryOne(t *testing.T) {
 	require.Equal(t, nullable.String(), *r.Nullable)
 }
 
+func Test_MariaDB_QueryOne_With_Named_Parameters(t *testing.T) {
+	// Arrange
+	require.NoError(t, tql.SetActiveDriver("mysql"))
+
+	id := uuid.New()
+	nullable := uuid.New()
+
+	_, err := mariaDB.Exec(fmt.Sprintf("INSERT INTO test (id, nullable) VALUES ('%s', '%s');", id.String(), nullable.String()))
+	require.NoError(t, err)
+
+	// Act
+	r, err := tql.QueryFirst[*string](
+		context.Background(),
+		mariaDB,
+		"SELECT id FROM test WHERE id = :id;",
+		map[string]any{"id": id},
+	)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.Equal(t, id.String(), *r)
+}
+
 func Test_MariaDB_QueryOne_String(t *testing.T) {
 	// Arrange
 	require.NoError(t, tql.SetActiveDriver("mysql"))

--- a/test/postgres_test.go
+++ b/test/postgres_test.go
@@ -299,6 +299,30 @@ func Test_Postgresql_QueryOne(t *testing.T) {
 	require.Equal(t, nullable.String(), *r.Nullable)
 }
 
+func Test_Postgresql_QueryOne_With_Named_Parameters(t *testing.T) {
+	// Arrange
+	require.NoError(t, tql.SetActiveDriver("postgres"))
+
+	id := uuid.New()
+	nullable := uuid.New()
+
+	_, err := pgDB.Exec(fmt.Sprintf("INSERT INTO test (id, nullable) VALUES ('%s', '%s');", id.String(), nullable.String()))
+	require.NoError(t, err)
+
+	// Act
+	r, err := tql.QueryFirst[*string](
+		context.Background(),
+		pgDB,
+		"SELECT id FROM test WHERE id = :id;",
+		map[string]any{"id": id},
+	)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.Equal(t, id.String(), *r)
+}
+
 func Test_Postgresql_QueryOne_String(t *testing.T) {
 	// Arrange
 	require.NoError(t, tql.SetActiveDriver("postgres"))
@@ -329,6 +353,30 @@ func Test_Postgresql_QueryOne_String_Pointer(t *testing.T) {
 
 	// Act
 	r, err := tql.QueryFirst[*string](context.Background(), pgDB, "SELECT id FROM test WHERE id = $1;", id)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.Equal(t, id.String(), *r)
+}
+
+func Test_Postgresql_QueryOne_With_Mixed_Named_Positional_Parameters_Returns_Error(t *testing.T) {
+	// Arrange
+	require.NoError(t, tql.SetActiveDriver("postgres"))
+
+	id := uuid.New()
+	nullable := uuid.New()
+
+	_, err := pgDB.Exec(fmt.Sprintf("INSERT INTO test (id, nullable) VALUES ('%s', '%s');", id.String(), nullable.String()))
+	require.NoError(t, err)
+
+	// Act
+	r, err := tql.QueryFirst[*string](
+		context.Background(),
+		pgDB,
+		"SELECT id FROM test WHERE id = :id;",
+		map[string]any{"id": id},
+	)
 
 	// Assert
 	require.NoError(t, err)

--- a/test/sqlite3_test.go
+++ b/test/sqlite3_test.go
@@ -297,6 +297,30 @@ func Test_Sqlite3_QueryOne(t *testing.T) {
 	require.Equal(t, nullable.String(), *r.Nullable)
 }
 
+func Test_Sqlite3_QueryOne_With_Named_Parameters(t *testing.T) {
+	// Arrange
+	require.NoError(t, tql.SetActiveDriver("sqlite3"))
+
+	id := uuid.New()
+	nullable := uuid.New()
+
+	_, err := sqlite3DB.Exec(fmt.Sprintf("INSERT INTO test (id, nullable) VALUES ('%s', '%s');", id.String(), nullable.String()))
+	require.NoError(t, err)
+
+	// Act
+	r, err := tql.QueryFirst[*string](
+		context.Background(),
+		sqlite3DB,
+		"SELECT id FROM test WHERE id = :id;",
+		map[string]any{"id": id},
+	)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.Equal(t, id.String(), *r)
+}
+
 func Test_Sqlite3_QueryOne_String(t *testing.T) {
 	// Arrange
 	require.NoError(t, tql.SetActiveDriver("sqlite3"))


### PR DESCRIPTION
Same as with exec, based on the driver, the query will be rewritten to replace all named parameters with positional ones, with positions of params being in the correct order.